### PR TITLE
Test main; increase coverage

### DIFF
--- a/gocover-cobertura.go
+++ b/gocover-cobertura.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+const coberturaDTDDecl = "<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n"
+
 func main() {
 	convert(os.Stdin, os.Stdout)
 }
@@ -35,7 +37,7 @@ func convert(in io.Reader, out io.Writer) {
 	coverage.parseProfiles(profiles)
 
 	fmt.Fprintf(out, xml.Header)
-	fmt.Fprintf(out, "<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n")
+	fmt.Fprintf(out, coberturaDTDDecl)
 
 	encoder := xml.NewEncoder(out)
 	encoder.Indent("", "\t")

--- a/gocover-cobertura_test.go
+++ b/gocover-cobertura_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"encoding/xml"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,6 +16,24 @@ const SaveTestResults = false
 
 type dirInfo struct {
 	PkgPath string
+}
+
+func TestMain(t *testing.T) {
+	fname := filepath.Join(os.TempDir(), "stdout")
+	temp, _ := os.Create(fname)
+	os.Stdout = temp
+	main()
+	outputBytes, err := ioutil.ReadFile(fname)
+	if err != nil {
+		t.Fail()
+	}
+	outputString := string(outputBytes)
+	if !strings.Contains(outputString, xml.Header) {
+		t.Fail()
+	}
+	if !strings.Contains(outputString, coberturaDTDDecl) {
+		t.Fail()
+	}
 }
 
 func TestConvertEmpty(t *testing.T) {


### PR DESCRIPTION
Before:

```
$ go test -cover -coverprofile cover.out && go tool cover -func=cover.out | egrep 'main|total'
ok  	github.com/t-yuki/gocover-cobertura	0.010s
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:18:	main		0.0%
total:								(statements)	69.9%
```

After:

```
$ go test -cover -coverprofile cover.out && go tool cover -func=cover.out | egrep 'main|total'
ok  	github.com/t-yuki/gocover-cobertura	0.012s
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:20:	main		100.0%
total:								(statements)	70.5%
```