### PR TITLE
More test coverage

### DIFF
--- a/gocover-cobertura_test.go
+++ b/gocover-cobertura_test.go
@@ -37,6 +37,24 @@ func TestConvertEmpty(t *testing.T) {
 	}
 }
 
+func TestParseProfileDoesntExist(t *testing.T) {
+	v := Coverage{}
+	profile := Profile{FileName: "does-not-exist"}
+	err := v.parseProfile(&profile)
+	if err == nil || !strings.Contains(err.Error(), `can't find "does-not-exist"`) {
+		t.Fatalf("Expected \"can't find\" error; got: %+v", err)
+	}
+}
+
+func TestParseProfileNotReadable(t *testing.T) {
+	v := Coverage{}
+	profile := Profile{FileName: os.DevNull}
+	err := v.parseProfile(&profile)
+	if err == nil || !strings.Contains(err.Error(), `expected 'package', found 'EOF'`) {
+		t.Fatalf("Expected \"expected 'package', found 'EOF'\" error; got: %+v", err)
+	}
+}
+
 func TestConvertSetMode(t *testing.T) {
 	tmpl, err := template.ParseFiles("testdata/testdata_set.txt")
 	if err != nil {


### PR DESCRIPTION
Before:

```
$ go test -cover -coverprofile cover.out && go tool cover -func=cover.out
PASS
coverage: 69.9% of statements
ok  	github.com/t-yuki/gocover-cobertura	0.011s
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:18:	main		0.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:22:	convert		88.2%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:50:	parseProfiles	100.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:58:	parseProfile	87.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:108:	Visit		100.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:121:	method		100.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:148:	class		100.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:159:	recvName	100.0%
github.com/t-yuki/gocover-cobertura/profile.go:39:		Len		100.0%
github.com/t-yuki/gocover-cobertura/profile.go:40:		Less		100.0%
github.com/t-yuki/gocover-cobertura/profile.go:41:		Swap		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:45:		ParseProfiles	89.7%
github.com/t-yuki/gocover-cobertura/profile.go:102:		Len		100.0%
github.com/t-yuki/gocover-cobertura/profile.go:103:		Swap		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:104:		Less		100.0%
github.com/t-yuki/gocover-cobertura/profile.go:111:		toInt		75.0%
github.com/t-yuki/gocover-cobertura/profile.go:130:		Boundaries	0.0%
github.com/t-yuki/gocover-cobertura/profile.go:179:		Len		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:180:		Swap		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:181:		Less		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:189:		findFile	66.7%
total:								(statements)	69.9%
```

After:

```
$ go test -cover -coverprofile cover.out && go tool cover -func=cover.out
PASS
coverage: 72.3% of statements
ok  	github.com/t-yuki/gocover-cobertura	0.012s
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:18:	main		0.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:22:	convert		88.2%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:50:	parseProfiles	100.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:58:	parseProfile	95.7%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:108:	Visit		100.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:121:	method		100.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:148:	class		100.0%
github.com/t-yuki/gocover-cobertura/gocover-cobertura.go:159:	recvName	100.0%
github.com/t-yuki/gocover-cobertura/profile.go:39:		Len		100.0%
github.com/t-yuki/gocover-cobertura/profile.go:40:		Less		100.0%
github.com/t-yuki/gocover-cobertura/profile.go:41:		Swap		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:45:		ParseProfiles	89.7%
github.com/t-yuki/gocover-cobertura/profile.go:102:		Len		100.0%
github.com/t-yuki/gocover-cobertura/profile.go:103:		Swap		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:104:		Less		100.0%
github.com/t-yuki/gocover-cobertura/profile.go:111:		toInt		75.0%
github.com/t-yuki/gocover-cobertura/profile.go:130:		Boundaries	0.0%
github.com/t-yuki/gocover-cobertura/profile.go:179:		Len		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:180:		Swap		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:181:		Less		0.0%
github.com/t-yuki/gocover-cobertura/profile.go:189:		findFile	88.9%
total:								(statements)	72.3%
```