### PR TITLE
Use testdata as-is without gen from template

### DIFF
--- a/gocover-cobertura_test.go
+++ b/gocover-cobertura_test.go
@@ -6,10 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
-	"text/template"
 )
 
 const SaveTestResults = false
@@ -115,22 +113,10 @@ func TestParseProfilePermissionDenied(t *testing.T) {
 }
 
 func TestConvertSetMode(t *testing.T) {
-	tmpl, err := template.ParseFiles("testdata/testdata_set.txt")
+	pipe1rd, err := os.Open("testdata/testdata_set.txt")
 	if err != nil {
 		t.Fatal("Can't parse testdata.")
 	}
-	dirInfo := dirInfo{}
-	dirInfo.PkgPath = reflect.TypeOf(Coverage{}).PkgPath()
-
-	pipe1rd, pipe1wr := io.Pipe()
-	go func() {
-		err := tmpl.Execute(pipe1wr, dirInfo)
-		if err != nil {
-			t.Error("Can't execute template.")
-			panic("tmpl.Execute failed")
-		}
-		pipe1wr.Close()
-	}()
 
 	pipe2rd, pipe2wr := io.Pipe()
 
@@ -163,7 +149,7 @@ func TestConvertSetMode(t *testing.T) {
 	}
 
 	p := v.Packages[0]
-	if strings.TrimRight(p.Name, "/") != dirInfo.PkgPath+"/testdata" {
+	if strings.TrimRight(p.Name, "/") != "./testdata" {
 		t.Fatal(p.Name)
 	}
 	if p.Classes == nil || len(p.Classes) != 2 {
@@ -174,8 +160,8 @@ func TestConvertSetMode(t *testing.T) {
 	if c.Name != "-" {
 		t.Error()
 	}
-	if c.Filename != dirInfo.PkgPath+"/testdata/func1.go" {
-		t.Errorf("Expected %s but %s", dirInfo.PkgPath+"/testdata/func1.go", c.Filename)
+	if c.Filename != "./testdata/func1.go" {
+		t.Errorf("Expected %s but %s", "./testdata/func1.go", c.Filename)
 	}
 	if c.Methods == nil || len(c.Methods) != 1 {
 		t.Fatal()
@@ -226,8 +212,8 @@ func TestConvertSetMode(t *testing.T) {
 	if c.Name != "Type1" {
 		t.Error()
 	}
-	if c.Filename != dirInfo.PkgPath+"/testdata/func2.go" {
-		t.Errorf("Expected %s but %s", dirInfo.PkgPath+"/testdata/func2.go", c.Filename)
+	if c.Filename != "./testdata/func2.go" {
+		t.Errorf("Expected %s but %s", "./testdata/func2.go", c.Filename)
 	}
 	if c.Methods == nil || len(c.Methods) != 3 {
 		t.Fatal()

--- a/testdata/testdata_set.txt
+++ b/testdata/testdata_set.txt
@@ -1,7 +1,7 @@
 mode: set
-{{.PkgPath}}/testdata/func1.go:4.23,5.16 1 1
-{{.PkgPath}}/testdata/func1.go:5.16,7.3 1 0
-{{.PkgPath}}/testdata/func2.go:7.34,8.16 1 1
-{{.PkgPath}}/testdata/func2.go:8.16,10.3 1 1
-{{.PkgPath}}/testdata/func2.go:13.35,14.2 0 0
-{{.PkgPath}}/testdata/func2.go:16.35,17.2 0 0
+./testdata/func1.go:4.23,5.16 1 1
+./testdata/func1.go:5.16,7.3 1 0
+./testdata/func2.go:7.34,8.16 1 1
+./testdata/func2.go:8.16,10.3 1 1
+./testdata/func2.go:13.35,14.2 0 0
+./testdata/func2.go:16.35,17.2 0 0


### PR DESCRIPTION
While trying to run `gocover-cobertura` on `testdata/testdata_set.txt`, I noticed that
it's actually a Go template; not actual data; so the tool can't process
it. The template seems to be just to replace `{{.PkgPath}}` with the
current directory. By using `.` instead in that file, it eliminates the
need for a bunch of code for rendering the template (it eliminates
2 stdlib imports, not that it's a big deal)

Before:

```
$ gocover-cobertura < testdata/testdata_set.txt | head -n 18
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage line-rate="0" branch-rate="0" version="" timestamp="1518632283054" lines-covered="0" lines-valid="0" branches-covered="0" branches-valid="0" complexity="0">
	<sources>
		<source>/usr/local/Cellar/go/1.10rc1/libexec/src</source>
		<source>/Users/abramowi/go/src</source>
	</sources>
	<packages></packages>
</coverage>
```

After:

```
$ gocover-cobertura < testdata/testdata_set.txt | head -n 18
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage line-rate="0" branch-rate="0" version="" timestamp="1518632265239" lines-covered="0" lines-valid="0" branches-covered="0" branches-valid="0" complexity="0">
	<sources>
		<source>/usr/local/Cellar/go/1.10rc1/libexec/src</source>
		<source>/Users/abramowi/go/src</source>
	</sources>
	<packages>
		<package name="./testdata" line-rate="0" branch-rate="0" complexity="0">
			<classes>
				<class name="-" filename="./testdata/func1.go" line-rate="0" branch-rate="0" complexity="0">
					<methods>
						<method name="Func1" signature="" line-rate="0" branch-rate="0" complexity="0">
							<lines>
								<line number="4" hits="1"></line>
								<line number="5" hits="1"></line>
								<line number="5" hits="0"></line>
								<line number="6" hits="0"></line>
```